### PR TITLE
Fix Treasury Address for Surge

### DIFF
--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"math"
 	"math/big"
-	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/tracing"
@@ -689,18 +688,9 @@ func (st *stateTransition) blobGasUsed() uint64 {
 	return uint64(len(st.msg.BlobHashes) * params.BlobTxBlobGasPerBlob)
 }
 
-// CHANGE(taiko): returns the treasury address based on chain ID.
+// CHANGE(taiko): returns the treasury address
 func (st *stateTransition) getTreasuryAddress() common.Address {
-	var (
-		prefix = st.evm.ChainConfig().ChainID.String()
-		suffix = "10001"
-	)
-	return common.HexToAddress(
-		"0x" +
-			prefix +
-			strings.Repeat("0", common.AddressLength*2-len(prefix)-len(suffix)) +
-			suffix,
-	)
+	return common.Address{}
 }
 
 // CHANGE(taiko): decodes an ontake block's extradata, returns basefeeSharingPctg configurations,

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -690,6 +690,10 @@ func (st *stateTransition) blobGasUsed() uint64 {
 
 // CHANGE(taiko): returns the treasury address
 func (st *stateTransition) getTreasuryAddress() common.Address {
+	// Use the FeeCollector, if available in the chain config.
+	if st.evm.ChainConfig().Taiko && st.evm.ChainConfig().FeeCollector != nil {
+		return *st.evm.ChainConfig().FeeCollector
+	}
 	return common.Address{}
 }
 

--- a/params/config.go
+++ b/params/config.go
@@ -414,9 +414,10 @@ type ChainConfig struct {
 	BlobScheduleConfig *BlobScheduleConfig `json:"blobSchedule,omitempty"`
 
 	// CHANGE(taiko): Taiko network flag.
-	Taiko       bool     `json:"taiko"`
-	OntakeBlock *big.Int `json:"ontakeBlock,omitempty"` // Ontake switch block (nil = no fork, 0 = already activated)
-	PacayaBlock *big.Int `json:"pacayaBlock,omitempty"` // Pacaya switch block (nil = no fork, 0 = already activated)
+	Taiko        bool            `json:"taiko"`
+	OntakeBlock  *big.Int        `json:"ontakeBlock,omitempty"` // Ontake switch block (nil = no fork, 0 = already activated)
+	PacayaBlock  *big.Int        `json:"pacayaBlock,omitempty"` // Pacaya switch block (nil = no fork, 0 = already activated)
+	FeeCollector *common.Address `json:"feeCollector,omitempty"`
 }
 
 // EthashConfig is the consensus engine configs for proof-of-work based sealing.


### PR DESCRIPTION
Caught state root mismatch due to different account balances.
Use null FeeCollector for treasury (similar to NMC)
Verified that all the block hashes match exactly in NMC & surge-geth now on staging devnet.